### PR TITLE
Remove react-outside-click-handler dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@carbonorm/carbonreact",
-  "version": "4.0.23",
+  "version": "4.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@carbonorm/carbonreact",
-      "version": "4.0.23",
+      "version": "4.0.24",
       "license": "MIT",
       "dependencies": {
         "@carbonorm/carbonnode": "^3.0.13",
@@ -23,7 +23,6 @@
         "jest-config": "^29.7.0",
         "qs": "^6.14.0",
         "react-loading-skeleton": "^3.5.0",
-        "react-outside-click-handler": "^1.3.0",
         "react-router-dom": "^7.5.0",
         "react-toastify": "^11.0.5",
         "typed-css-modules": "^0.9.1",
@@ -619,7 +618,6 @@
         "jest-config": "^29.7.0",
         "qs": "^6.14.0",
         "react-loading-skeleton": "^3.5.0",
-        "react-outside-click-handler": "^1.3.0",
         "react-router-dom": "^7.5.0",
         "react-toastify": "^11.0.5",
         "typed-css-modules": "^0.9.1",
@@ -9489,47 +9487,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/react-outside-click-handler": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.3.0.tgz",
-      "integrity": "sha512-Te/7zFU0oHpAnctl//pP3hEAeobfeHMyygHB8MnjP6sX5OR8KHT1G3jmLsV3U9RnIYo+Yn+peJYWu+D5tUS8qQ==",
-      "license": "MIT",
-      "dependencies": {
-        "airbnb-prop-types": "^2.15.0",
-        "consolidated-events": "^1.1.1 || ^2.0.0",
-        "document.contains": "^1.0.1",
-        "object.values": "^1.1.0",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^0.14 || >=15",
-        "react-dom": "^0.14 || >=15"
-      }
-    },
-    "node_modules/react-outside-click-handler/node_modules/airbnb-prop-types": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
-      "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
-      "deprecated": "This package has been renamed to 'prop-types-tools'",
-      "license": "MIT",
-      "dependencies": {
-        "array.prototype.find": "^2.1.1",
-        "function.prototype.name": "^1.1.2",
-        "is-regex": "^1.1.0",
-        "object-is": "^1.1.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "prop-types-exact": "^1.2.0",
-        "react-is": "^16.13.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "react": "^0.14 || ^15.0.0 || ^16.0.0-alpha"
       }
     },
     "node_modules/react-router": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "jest-config": "^29.7.0",
     "qs": "^6.14.0",
     "react-loading-skeleton": "^3.5.0",
-    "react-outside-click-handler": "^1.3.0",
     "react-router-dom": "^7.5.0",
     "react-toastify": "^11.0.5",
     "typed-css-modules": "^0.9.1",

--- a/src/components/Errors/BackendThrowable.tsx
+++ b/src/components/Errors/BackendThrowable.tsx
@@ -1,5 +1,5 @@
 import styles from './style.module.scss';
-import OutsideClickHandler from 'react-outside-click-handler';
+import OutsideClickHandler from '../OutsideClickHandler/OutsideClickHandler';
 import CarbonReact, {iCarbonReactState} from "../../CarbonReact";
 import {ReactElement} from "react";
 

--- a/src/components/OutsideClickHandler/OutsideClickHandler.tsx
+++ b/src/components/OutsideClickHandler/OutsideClickHandler.tsx
@@ -1,0 +1,33 @@
+import { ReactNode, useRef, useEffect } from 'react';
+
+interface OutsideClickHandlerProps {
+    onOutsideClick: () => any;
+    children: ReactNode;
+    disabled?: boolean;
+    useCapture?: boolean;
+}
+
+export default function OutsideClickHandler({ onOutsideClick, children, disabled, useCapture }: OutsideClickHandlerProps) {
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (disabled) {
+            return;
+        }
+        function handle(event: MouseEvent | TouchEvent) {
+            const element = containerRef.current;
+            if (!element || element.contains(event.target as Node)) {
+                return;
+            }
+            onOutsideClick();
+        }
+        document.addEventListener('mousedown', handle, useCapture);
+        document.addEventListener('touchstart', handle, useCapture);
+        return () => {
+            document.removeEventListener('mousedown', handle, useCapture);
+            document.removeEventListener('touchstart', handle, useCapture);
+        };
+    }, [onOutsideClick, disabled, useCapture]);
+
+    return <div ref={containerRef}>{children}</div>;
+}

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import OutsideClickHandler from 'react-outside-click-handler';
+import OutsideClickHandler from '../OutsideClickHandler/OutsideClickHandler';
 import getStyles from "hoc/getStyles";
 import {PropsWithChildren, ReactElement} from "react";
 


### PR DESCRIPTION
## Summary
- drop `react-outside-click-handler` from dependencies
- implement a lightweight local OutsideClickHandler component
- update `BackendThrowable` and `Popup` to use the new component

## Testing
- `npm test` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868432622c083259d4a875ba539cfd2